### PR TITLE
Regex fix, replaced obsolete constructor (update)

### DIFF
--- a/Net/FTP.php
+++ b/Net/FTP.php
@@ -707,7 +707,7 @@ class Net_FTP extends PEAR
      * @return void
      * @see Net_FTP::setHostname(), Net_FTP::setPort(), Net_FTP::connect()
      */
-    function Net_FTP($host = null, $port = null, $timeout = 90)
+    function __construct($host = null, $port = null, $timeout = 90)
     {
         $this->PEAR();
         if (isset($host)) {
@@ -724,7 +724,7 @@ class Net_FTP extends PEAR
                  * Fix regex - based on MehrAlsNix/php-ftp-client@9cd5d0b via
                  * https://github.com/phingofficial/phing/issues/1224
                  */
-                'pattern' => '/(?:(d)|.)([rwxts-]{9})\s+(\w+)\s+([\w\-()?.]+)\s+'.
+                'pattern' => '/(?:(d)|.)([rwxts\-]{9})\s+(\w+)\s+([\w\-()?.]+)\s+'.
                              '([\w\-()?.]+)\s+(\w+)\s+(\S+\s+\S+\s+\S+)\s+(.+)/',
                 'map'     => array(
                     'is_dir'        => 1,


### PR DESCRIPTION
Rebased my branch to fix the conflicts from #8.

Fixed the regex to work with PHP7+, where rules regarding hyphens in character classes have become more strict. Escaped all hyphens in character classes that needed escaping, so the regex works as intended. This can be done safely, since it is compatible with older versions of PHP, which were simply more tolerant.

Additionally, replaced the old style constructor with __construct().